### PR TITLE
add allowManualNc option

### DIFF
--- a/lib/js/candlestick.js
+++ b/lib/js/candlestick.js
@@ -5,7 +5,7 @@
  * ======================================================================== */
 
 "use strict";
-(function($) {
+(function(jQuery) {
 
     /** Storage of the candlestick's settings */
     var candlestickOptions = {};
@@ -35,13 +35,13 @@
      * @property {function}
      * @property {function}
      */
-    $.fn.candlestick = function(options) {
+    jQuery.fn.candlestick = function(options) {
         if (options == 'val') {
-            if ($(this).find('input[type="hidden"]')) {
-                return $(this).find('input[type="hidden"]').val();
+            if (jQuery(this).find('input[type="hidden"]')) {
+                return jQuery(this).find('input[type="hidden"]').val();
             }
             else {
-                return $(this).val();
+                return jQuery(this).val();
             }
         }
 
@@ -58,7 +58,7 @@
                         desktop: true,
                         transition: false
                     };
-                    swipe = $.extend(defaultSwipeOptions, options.swipe);
+                    swipe = jQuery.extend(defaultSwipeOptions, options.swipe);
                 }
             }
         }
@@ -77,6 +77,7 @@
             'size': 'md',
             'swipe': swipe,
             'debug': false,
+            'allowManualNc': true,
             afterAction: function() {},
             afterRendering: function() {},
             afterOrganization: function() {},
@@ -84,17 +85,17 @@
             customVars: function(settings) {return settings;}
         };
 
-        if (candlestickOptions[$(this).attr('id')]) {
-            defaults = candlestickOptions[$(this).attr('id')];
+        if (candlestickOptions[jQuery(this).attr('id')]) {
+            defaults = candlestickOptions[jQuery(this).attr('id')];
         }
 
         // Do options like reset or change value
-        if ((typeof options) == 'string' && $(this).attr('id')) {
+        if ((typeof options) == 'string' && jQuery(this).attr('id')) {
             // Condition about the choose option
             switch (options) {
                 case 'on':
                     return this.each(function() {
-                        var candlestick = candlestickLightInitialize($(this), defaults);
+                        var candlestick = candlestickLightInitialize(jQuery(this), defaults);
                         candlestick.defaultOrganization();
                         candlestick.setBackground('on');
                         candlestick.setHandle(1);
@@ -102,7 +103,7 @@
                 break;
                 case 'off':
                     return this.each(function() {
-                        var candlestick = candlestickLightInitialize($(this), defaults);
+                        var candlestick = candlestickLightInitialize(jQuery(this), defaults);
                         candlestick.defaultOrganization();
                         candlestick.setBackground('off');
                         candlestick.setHandle(-1);
@@ -111,41 +112,41 @@
                 case 'reset':
                 case 'default':
                     return this.each(function() {
-                        var candlestick = candlestickLightInitialize($(this), defaults);
+                        var candlestick = candlestickLightInitialize(jQuery(this), defaults);
                         candlestick.defaultOrganization();
                         candlestick.setValue(0);
                     });
                 break;
                 case 'enable':
                     return this.each(function() {
-                        var candlestick = candlestickLightInitialize($(this), defaults);
+                        var candlestick = candlestickLightInitialize(jQuery(this), defaults);
                         candlestick.parent.removeClass('candlestick-disabled');
                     });
                 break;
                 case 'disable':
                     return this.each(function() {
-                        var candlestick = candlestickLightInitialize($(this), defaults);
+                        var candlestick = candlestickLightInitialize(jQuery(this), defaults);
                         candlestick.parent.addClass('candlestick-disabled');
                     });
                 break;
             }
         }
 
-        var settings = $.extend(defaults, options);
+        var settings = jQuery.extend(defaults, options);
 
         return this.each(function() {
-            if ($(this).attr('type') == 'checkbox') {
-                if ($(this).attr('id')) {
-                    var candlestick = new Candlestick($(this), settings);
-                    candlestickOptions[$(this).attr('id')] = settings;
+            if (jQuery(this).attr('type') == 'checkbox') {
+                if (jQuery(this).attr('id')) {
+                    var candlestick = new Candlestick(jQuery(this), settings);
+                    candlestickOptions[jQuery(this).attr('id')] = settings;
                     candlestick.initialize();
                 }
                 else {
-                    $.error('Candlestick needs an unique id attribute to store settings !!!');
+                    jQuery.error('Candlestick needs an unique id attribute to store settings !!!');
                 }
             }
             else {
-                $.error('Candlestick only used on checkbox input fields !!!');
+                jQuery.error('Candlestick only used on checkbox input fields !!!');
             }
         });
     }
@@ -213,53 +214,53 @@ Candlestick.prototype.initialize = function () {
  */
 Candlestick.prototype.wrapElement = function () {
     this.log('Create HTMLCandlestick element');
-    var $classes = '';
+    var jQueryclasses = '';
 
-    var $id = '';
+    var jQueryid = '';
     if (this.default.id)
-        $id = this.default.id;
+        jQueryid = this.default.id;
     else
-        $id = this.default.name.replace(/[\[\]]/gi, "");
+        jQueryid = this.default.name.replace(/[\[\]]/gi, "");
 
-    this.log('ID : ' + $id);
-    this.default.id = $id;
+    this.log('ID : ' + jQueryid);
+    this.default.id = jQueryid;
 
     var datas = '';
     if (this.default.data) {
-        var $data = this.default.data;
-        for (var d in $data) {
-            datas += ' data-' + d + '="' + $data[d] + '"';
+        var jQuerydata = this.default.data;
+        for (var d in jQuerydata) {
+            datas += ' data-' + d + '="' + jQuerydata[d] + '"';
         }
     }
 
-    var $inputDisabled = '';
+    var jQueryinputDisabled = '';
     if (this.element.attr('disabled')) {
-        $classes = ' candlestick-disabled';
-        $inputDisabled = ' disabled';
+        jQueryclasses = ' candlestick-disabled';
+        jQueryinputDisabled = ' disabled';
     }
 
-    var $inputReadonly = '';
+    var jQueryinputReadonly = '';
     if (this.element.attr('readonly')) {
-        $classes = ' candlestick-disabled readonly';
-        $inputReadonly = ' readonly';
+        jQueryclasses = ' candlestick-disabled readonly';
+        jQueryinputReadonly = ' readonly';
     }
 
     if (this.isSwipeEnable()) {
-        $classes += ' grab';
+        jQueryclasses += ' grab';
     }
 
     switch (this.settings.mode) {
         case 'contents':
-            var html = '<div class="candlestick-wrapper candlestick-contents"><div data-candlestick-id="' + $id + '" class="candlestick-bg' + $classes + '"><div class="candlestick-toggle"></div><div class="candlestick-off" data-content="' + this.settings.contents.left + '"></div>';
+            var html = '<div class="candlestick-wrapper candlestick-contents"><div data-candlestick-id="' + jQueryid + '" class="candlestick-bg' + jQueryclasses + '"><div class="candlestick-toggle"></div><div class="candlestick-off" data-content="' + this.settings.contents.left + '"></div>';
 
             if (this.settings.contents.middle) {
                 html += '<div class="candlestick-nc" data-content="' + this.settings.contents.middle + '"></div>';
             }
 
-            html += '<div class="candlestick-on" data-content="' + this.settings.contents.right + '"></div><input type="hidden" class="' + this.element.attr('class') + '" value="' + this.default.value + '" name="' + this.default.name + '" id="' + $id + '"' + datas + $inputDisabled + $inputReadonly + '></div></div>';
+            html += '<div class="candlestick-on" data-content="' + this.settings.contents.right + '"></div><input type="hidden" class="' + this.element.attr('class') + '" value="' + this.default.value + '" name="' + this.default.name + '" id="' + jQueryid + '"' + datas + jQueryinputDisabled + jQueryinputReadonly + '></div></div>';
         break;
         default:
-            var html = '<div class="candlestick-wrapper candlestick-size-' + this.settings.size + '"><div data-candlestick-id="' + $id + '" class="candlestick-bg' + $classes + '"><div class="candlestick-toggle"></div><div class="candlestick-off"><i class="fa fa-times"></i></div><div class="candlestick-nc">&nbsp;</div><div class="candlestick-on"><i class="fa fa-check"></i></div><input type="hidden" class="' + this.element.attr('class') + '" value="' + this.default.value + '" name="' + this.default.name + '" id="' + $id + '"' + datas + $inputDisabled + $inputReadonly + '></div></div>';
+            var html = '<div class="candlestick-wrapper candlestick-size-' + this.settings.size + '"><div data-candlestick-id="' + jQueryid + '" class="candlestick-bg' + jQueryclasses + '"><div class="candlestick-toggle"></div><div class="candlestick-off"><i class="fa fa-times"></i></div><div class="candlestick-nc">&nbsp;</div><div class="candlestick-on"><i class="fa fa-check"></i></div><input type="hidden" class="' + this.element.attr('class') + '" value="' + this.default.value + '" name="' + this.default.name + '" id="' + jQueryid + '"' + datas + jQueryinputDisabled + jQueryinputReadonly + '></div></div>';
         break;
     }
 
@@ -404,7 +405,7 @@ Candlestick.prototype.defaultOrganization = function () {
  */
 Candlestick.prototype.mouseContents = function () {
     var that = this;
-    $('.candlestick-bg').on('mousedown', function(e) {
+    jQuery('.candlestick-bg').on('mousedown', function(e) {
         e.preventDefault();
         e.stopPropagation();
 
@@ -413,8 +414,8 @@ Candlestick.prototype.mouseContents = function () {
             offsetX: 0
         };
 
-        $(this).addClass('move');
-        that.mouseEvent.leftElement = parseInt($(this).find('.candlestick-toggle').css('left'));
+        jQuery(this).addClass('move');
+        that.mouseEvent.leftElement = parseInt(jQuery(this).find('.candlestick-toggle').css('left'));
         that.mouseEvent.offsetX = e.pageX;
     })
     .on('mousemove', function(e) {
@@ -423,7 +424,7 @@ Candlestick.prototype.mouseContents = function () {
         e.preventDefault();
         e.stopPropagation();
 
-        if ($(this).hasClass('move')) {
+        if (jQuery(this).hasClass('move')) {
             // MOVE LEFT
             if (e.pageX < that.mouseEvent.offsetX) {
                 move = e.pageX - that.mouseEvent.offsetX;
@@ -433,23 +434,23 @@ Candlestick.prototype.mouseContents = function () {
                 move = e.pageX - that.mouseEvent.offsetX;
             }
 
-            var leftPosition = that.slot($(this), move);
-            $(this).find('.candlestick-toggle').css('left', leftPosition);
+            var leftPosition = that.slot(jQuery(this), move);
+            jQuery(this).find('.candlestick-toggle').css('left', leftPosition);
         }
     })
     .on('mouseup', function(e) {
         e.preventDefault();
         e.stopPropagation();
 
-        $(this).removeClass('move');
-        that.placeToggle($(this));
+        jQuery(this).removeClass('move');
+        that.placeToggle(jQuery(this));
     });
 };
 
 /**
  * Place the toggle button by his left position
  *
- * @param element jQuery element $('.candlestick-bg')
+ * @param element jQuery element jQuery('.candlestick-bg')
  * @return void
  */
 Candlestick.prototype.placeToggle = function (element) {
@@ -486,7 +487,7 @@ Candlestick.prototype.placeToggle = function (element) {
 /**
  * The toggle button can not exit his parent slot
  *
- * @param element jQuery element $('.candlestick-bg')
+ * @param element jQuery element jQuery('.candlestick-bg')
  * @param move int Move integer
  * @return int The new left position
  */
@@ -619,7 +620,8 @@ Candlestick.prototype.actionDefault = function () {
     var that = this;
     this.parent.find('.candlestick-nc').on('click', function(e) {
         e.preventDefault();
-        if (!that.parent.hasClass('candlestick-disabled')) {
+        
+        if (!that.parent.hasClass('candlestick-disabled') && that.settings.allowManualNc) {
             that.putDefault('default');
         }
     });
@@ -644,7 +646,7 @@ Candlestick.prototype.actionSwipe = function () {
     var that = this;
 
     if (that.isSwipeEnable()) {
-        if (typeof $.fn.hammer != 'undefined') {
+        if (typeof jQuery.fn.hammer != 'undefined') {
             that.log('Hammerjs is enable');
 
             var element = that.parent.find('.candlestick-toggle');
@@ -687,17 +689,17 @@ Candlestick.prototype.actionSwipe = function () {
             })
             .bind("swipeleft", function(e) {
                 if (that.getMode('contents')) {
-                    that.swipeElementContents($(this), -1);
+                    that.swipeElementContents(jQuery(this), -1);
                 }
             })
             .bind("swiperight", function(e) {
                 if (that.getMode('contents')) {
-                    that.swipeElementContents($(this), 1);
+                    that.swipeElementContents(jQuery(this), 1);
                 }
             });
         }
         else {
-            $.error('You have to load hammerjs && jquery-hammerjs lib to use swipe option');
+            jQuery.error('You have to load hammerjs && jquery-hammerjs lib to use swipe option');
         }
     }
 };
@@ -776,9 +778,9 @@ Candlestick.prototype.getMode = function (mode) {
  */
 Candlestick.prototype.delete = function () {
     this.element.remove();
-    this.parent = $('[data-candlestick-id="' + this.default.id + '"]');
+    this.parent = jQuery('[data-candlestick-id="' + this.default.id + '"]');
     this.handle = this.parent.find('.candlestick-toggle');
-    this.element = $('#' + this.default.id);
+    this.element = jQuery('#' + this.default.id);
 };
 
 /**
@@ -803,7 +805,7 @@ Candlestick.prototype.log = function (string) {
  * @return Object
  */
 function candlestickLightInitialize(element, settings) {
-    var candle = $('#' + element.attr('id'));
+    var candle = jQuery('#' + element.attr('id'));
     var candlestick = new Candlestick(candle, settings);
     candlestick.parent = candle.parent();
     candlestick.handle = candlestick.parent.find('.candlestick-toggle');


### PR DESCRIPTION
1) replaced $ with jQuery to allow noConflict() versions where the default jQuery alias $ is used by another application

2) I've added a 'allowManualNc' setting to create a way where the user can not manually select the default/no value option.
